### PR TITLE
Initialize mods path at startup

### DIFF
--- a/Code/app/barotrauma_window.py
+++ b/Code/app/barotrauma_window.py
@@ -88,45 +88,6 @@ class BarotraumaWindow:
                 dpg.configure_item("barotrauma_cur_path_valid", color=[0, 255, 0])
 
                 AppConfig.set("barotrauma_dir", str(path))
-                if "Steam" in path.parts:  # Sorry pirates, but not today
-                    if platform.system() == "Windows":
-                        path_to_mod = (
-                            Path.home()
-                            / "AppData"
-                            / "Local"
-                            / "Daedalic Entertainment GmbH"
-                            / "Barotrauma"
-                            / "WorkshopMods"
-                            / "Installed"
-                        )
-
-                    elif platform.system() == "Linux":
-                        path_to_mod = (
-                            Path.home()
-                            / ".local"
-                            / "share"
-                            / "Daedalic Entertainment GmbH"
-                            / "Barotrauma"
-                            / "WorkshopMods"
-                            / "Installed"
-                        )
-
-                    elif platform.system() == "Darwin":
-                        path_to_mod = (
-                            Path.home()
-                            / "Library"
-                            / "Application Support"
-                            / "Daedalic Entertainment GmbH"
-                            / "Barotrauma"
-                            / "WorkshopMods"
-                            / "Installed"
-                        )
-
-                    else:
-                        raise RuntimeError("Unknown operating system")
-
-                    AppConfig.set("barotrauma_install_mod_dir", str(path_to_mod))
-
                 logger.info(f"Valid path set: {path}")
 
                 ModManager.load_mods()

--- a/Code/app/barotrauma_window.py
+++ b/Code/app/barotrauma_window.py
@@ -88,6 +88,7 @@ class BarotraumaWindow:
                 dpg.configure_item("barotrauma_cur_path_valid", color=[0, 255, 0])
 
                 AppConfig.set("barotrauma_dir", str(path))
+                AppConfig.get_mods_path()
                 logger.info(f"Valid path set: {path}")
 
                 ModManager.load_mods()

--- a/Code/app_vars.py
+++ b/Code/app_vars.py
@@ -37,7 +37,6 @@ class AppConfig:
         cls._user_data_path.mkdir(parents=True, exist_ok=True)
         cls._load_user_config()
         cls.set("debug", debug)
-        cls.get_mods_path()
         atexit.register(cls._save_user_config)
 
     @classmethod

--- a/Code/app_vars.py
+++ b/Code/app_vars.py
@@ -87,3 +87,48 @@ class AppConfig:
             return
 
         return game_path
+
+    @classmethod
+    def get_mods_path(cls) -> None:
+        path = Path.home()
+
+        if not path.exists():
+            return
+
+        if platform.system() == "Windows":
+            path_to_mod = (
+                    Path.home()
+                    / "AppData"
+                    / "Local"
+                    / "Daedalic Entertainment GmbH"
+                    / "Barotrauma"
+                    / "WorkshopMods"
+                    / "Installed"
+            )
+
+        elif platform.system() == "Linux":
+            path_to_mod = (
+                    Path.home()
+                    / ".local"
+                    / "share"
+                    / "Daedalic Entertainment GmbH"
+                    / "Barotrauma"
+                    / "WorkshopMods"
+                    / "Installed"
+            )
+
+        elif platform.system() == "Darwin":
+            path_to_mod = (
+                    Path.home()
+                    / "Library"
+                    / "Application Support"
+                    / "Daedalic Entertainment GmbH"
+                    / "Barotrauma"
+                    / "WorkshopMods"
+                    / "Installed"
+            )
+
+        else:
+            raise RuntimeError("Unknown operating system")
+
+        AppConfig.set("barotrauma_install_mod_dir", str(path_to_mod))

--- a/Code/app_vars.py
+++ b/Code/app_vars.py
@@ -91,11 +91,6 @@ class AppConfig:
 
     @classmethod
     def get_mods_path(cls) -> None:
-        path = Path.home()
-
-        if not path.exists():
-            return
-
         if platform.system() == "Windows":
             path_to_mod = (
                     Path.home()
@@ -106,7 +101,6 @@ class AppConfig:
                     / "WorkshopMods"
                     / "Installed"
             )
-
         elif platform.system() == "Linux":
             path_to_mod = (
                     Path.home()
@@ -117,7 +111,6 @@ class AppConfig:
                     / "WorkshopMods"
                     / "Installed"
             )
-
         elif platform.system() == "Darwin":
             path_to_mod = (
                     Path.home()
@@ -128,7 +121,6 @@ class AppConfig:
                     / "WorkshopMods"
                     / "Installed"
             )
-
         else:
             raise RuntimeError("Unknown operating system")
 

--- a/Code/app_vars.py
+++ b/Code/app_vars.py
@@ -37,6 +37,7 @@ class AppConfig:
         cls._user_data_path.mkdir(parents=True, exist_ok=True)
         cls._load_user_config()
         cls.set("debug", debug)
+        cls.get_mods_path()
         atexit.register(cls._save_user_config)
 
     @classmethod

--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ def configure_logging(debug: bool):
 def init_app_config(debug: bool) -> None:
     logging.debug("Initializing AppConfig...")
     AppConfig.init(debug)
+    AppConfig.get_mods_path()
     logging.debug("AppConfig initialization complete.")
 
 

--- a/main.py
+++ b/main.py
@@ -51,7 +51,6 @@ def configure_logging(debug: bool):
 def init_app_config(debug: bool) -> None:
     logging.debug("Initializing AppConfig...")
     AppConfig.init(debug)
-    AppConfig.get_mods_path()
     logging.debug("AppConfig initialization complete.")
 
 


### PR DESCRIPTION
The problem with #21 is that mods path does not initialize as it should.
For some reason there is `validate_barotrauma_path()` which should do all the magic, but it doesn't.

Although, my point is to get all config-related variables at program startup not at window render.
Furthermore, mods directory does not belong to Barotrauma installation path, so we are able to check `AppData` without validation. At least without installation validation.

The current stable version neither set `barotrauma_install_mod_dir` key in `AppConfig`, nor save it to the config.
It works like a charm, if the path was set manually though.

No mods path (version 0.1.0)
![image](https://github.com/user-attachments/assets/36f7be86-2fc5-423a-abd1-6f69e8308a87)

Mods path (version 0.1.0)
![image](https://github.com/user-attachments/assets/d04a6eb6-d197-4c45-8f80-ba4cb75f73b5)

Fixes: #21 