### PR TITLE
No GUI start

### DIFF
--- a/Code/app/barotrauma_window.py
+++ b/Code/app/barotrauma_window.py
@@ -1,13 +1,11 @@
 import logging
-import os
-import platform
-import string
 import threading
 from pathlib import Path
 
 import dearpygui.dearpygui as dpg
 
 from Code.app_vars import AppConfig
+from Code.game import Game
 from Code.loc import Localization as loc
 from Code.package import ModManager
 
@@ -181,7 +179,7 @@ class BarotraumaWindow:
         )
         dpg.add_loading_indicator(style=2, parent="exp_game")
 
-        results = BarotraumaWindow._search_all_games_on_all_drives()
+        results = Game.search_all_games_on_all_drives()
         dpg.delete_item("exp_game", children_only=True)
 
         if results:
@@ -216,145 +214,3 @@ class BarotraumaWindow:
             daemon=True,
         ).start()
         dpg.delete_item("exp_game")
-
-    @staticmethod
-    def _is_system_directory(path):
-        if platform.system() == "Windows":
-            system_dirs = [
-                Path("C:\\Windows"),
-                Path("C:\\Program Files"),
-                Path("C:\\Program Files (x86)"),
-            ]
-            return path in system_dirs or path.is_relative_to(Path("C:\\Windows"))
-
-        else:
-            system_dirs = [
-                Path("/usr"),
-                Path("/etc"),
-                Path("/bin"),
-                Path("/sys"),
-                Path("/sbin"),
-                Path("/proc"),
-                Path("/dev"),
-                Path("/run"),
-                Path("/tmp"),
-                Path("/var"),
-                Path("/boot"),
-                Path("/lib"),
-                Path("/lib64"),
-                Path("/opt"),
-                Path("/lost+found"),
-                Path("/snap"),
-                Path("/srv"),
-            ]
-
-            return path in system_dirs
-
-    @staticmethod
-    def _should_ignore_directory(entry, current_dir, game_name):
-        ignored_directories = {
-            "appdata",
-            "temp",
-            "cache",
-            "logs",
-            "backup",
-            "bin",
-            "obj",
-            "history",
-            "httpcache",
-            "venv",
-            "tmp",
-            "programdata",
-        }
-
-        entry_name_lower = entry.name.lower()
-
-        if entry_name_lower != ".steam" and (
-            entry_name_lower.startswith((".", "_", "$", "~"))
-            or entry_name_lower in ignored_directories
-        ):
-            logger.debug(f"Ignoring directory: {entry}")
-            return True
-
-        expected_structure = {
-            ".steam": "steam",
-            "steam": "steamapps",
-            "steamapps": "common",
-            "common": game_name.lower(),
-        }
-
-        expected_entry = expected_structure.get(current_dir.name.lower())
-        if expected_entry and entry_name_lower != expected_entry:
-            logger.debug(
-                f"Ignoring directory: {entry} (in {current_dir.name}, not {expected_entry})"
-            )
-            return True
-
-        return False
-
-    @staticmethod
-    def _search_all_games_on_all_drives():
-        game_name = "barotrauma"
-
-        if platform.system() == "Windows":
-            drives = [
-                Path(f"{drive}:\\")
-                for drive in string.ascii_uppercase
-                if Path(f"{drive}:\\").exists() and os.access(f"{drive}:\\", os.R_OK)
-            ]
-
-        else:
-            drives = [
-                Path(mount_point)
-                for mount_point in Path("/mnt").glob("*")
-                if mount_point.is_dir()
-            ]
-
-        logger.debug(f"Found drives: {len(drives)}")
-
-        found_paths = []
-
-        for drive in drives:
-            logger.debug(f"Processing drive: {drive}")
-            dirs_to_visit = [drive]
-
-            while dirs_to_visit:
-                current_dir = dirs_to_visit.pop()
-                logger.debug(f"Processing directory: {current_dir}")
-
-                if BarotraumaWindow._is_system_directory(current_dir):
-                    logger.debug(f"Ignoring system folder: {current_dir}")
-                    continue
-
-                try:
-                    for entry in current_dir.iterdir():
-                        if entry.is_dir():
-                            if BarotraumaWindow._should_ignore_directory(
-                                entry, current_dir, game_name
-                            ):
-                                continue
-
-                            if entry.name.lower() == game_name:
-                                logger.debug(f"Match found: {entry}")
-                                found_paths.append(entry)
-                            else:
-                                dirs_to_visit.append(entry)
-
-                except PermissionError:
-                    logger.debug(f"Access to directory {current_dir} denied")
-
-                except Exception as e:
-                    logger.debug(f"Error processing directory {current_dir}: {e}")
-
-        executable_name = (
-            "barotrauma.exe" if platform.system() == "Windows" else "barotrauma"
-        )
-
-        valid_paths = []
-        for path in found_paths:
-            for exec_file in path.rglob("[Bb]arotrauma*"):
-                if exec_file.name.lower() == executable_name:
-                    logger.debug(f"Verified executable in path: {exec_file}")
-                    valid_paths.append(path)
-
-        return valid_paths

--- a/main.py
+++ b/main.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
                 "ModLoader may have bugs on MacOS. Please report any issues to https://github.com/themanyfaceddemon/Mod_Loader/issues"
             )
 
-        if args.ngui is None:
+        if not args.ngui:
             main(args.debug)
 
         else:

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from colorama import Fore, Style, init
 
 from Code.app import App
 from Code.app_vars import AppConfig
+from Code.game import Game
 from Code.loc import Localization as loc
 from Code.package import ModManager
 
@@ -77,6 +78,30 @@ def init_classes(debug: bool) -> None:
     logging.debug("Application initialization complete.")
 
 
+def args_no_gui(
+    start_game: bool, auto_game_path: bool, auto_lua: bool, skip_intro: bool
+):
+    if auto_game_path:
+        game_path = AppConfig.get_game_path()
+        if game_path is None:
+            res = Game.search_all_games_on_all_drives()
+            if res:
+                AppConfig.set("barotrauma_dir", str(res[0]))
+                AppConfig.get_mods_path()
+                ModManager.load_mods()
+                ModManager.load_cslua_config()
+
+            else:
+                logging.error("Failed to set game path")
+                return
+
+    if auto_lua:
+        Game.download_update_lua()
+
+    if start_game:
+        Game.run_game(skip_intro=skip_intro)
+
+
 def main(debug: bool) -> None:
     logging.debug("Starting program...")
     init_classes(debug)
@@ -94,6 +119,25 @@ if __name__ == "__main__":
 
         parser = argparse.ArgumentParser()
         parser.add_argument("--debug", action="store_true", help="Enable debug mode")
+        parser.add_argument(
+            "--ngui",
+            action="store_true",
+            help="Disables GUI startup, required to run other flags",
+        )
+        parser.add_argument(
+            "--sg", action="store_true", help="Automatically launch the game"
+        )
+        parser.add_argument(
+            "--apath",
+            action="store_true",
+            help="Automatically set the path if it does not exist",
+        )
+        parser.add_argument(
+            "--alua", action="store_true", help="Automatic update / installation of lua"
+        )
+        parser.add_argument(
+            "--si", action="store_true", help="Skip intro. Doesn't work without --sg"
+        )
         args = parser.parse_args()
 
         configure_logging(args.debug)
@@ -103,7 +147,11 @@ if __name__ == "__main__":
                 "ModLoader may have bugs on MacOS. Please report any issues to https://github.com/themanyfaceddemon/Mod_Loader/issues"
             )
 
-        main(args.debug)
+        if args.ngui is None:
+            main(args.debug)
+
+        else:
+            args_no_gui(args.sg, args.apath, args.alua, args.si)
 
     except Exception:
         exc_type, exc_value, exc_tb = sys.exc_info()

--- a/main.py
+++ b/main.py
@@ -147,11 +147,11 @@ if __name__ == "__main__":
                 "ModLoader may have bugs on MacOS. Please report any issues to https://github.com/themanyfaceddemon/Mod_Loader/issues"
             )
 
-        if not args.ngui:
-            main(args.debug)
+        if args.ngui:
+            args_no_gui(args.sg, args.apath, args.alua, args.si)
 
         else:
-            args_no_gui(args.sg, args.apath, args.alua, args.si)
+            main(args.debug)
 
     except Exception:
         exc_type, exc_value, exc_tb = sys.exc_info()


### PR DESCRIPTION
Adds flags to run the application not through the GUI
```
--ngui - Disables GUI. Must be if other flags need to be used
--sg - Launches the game
--apath - Automatically tries to find the path if not set in the config and uses it. Significantly slows everything down
--alua - Automatic update / installation of lua
--si - Skip intro. Doesn't work without --sg
```